### PR TITLE
(Fix Vul: Nginx) 修复 curl未指定charset时乱码的问题

### DIFF
--- a/n/nginx/1/README.md
+++ b/n/nginx/1/README.md
@@ -63,7 +63,7 @@ Accept-Ranges: bytes
 2. 请求时设置 range 如下：
 
 ```
-$ curl -i http://127.0.0.1:8000/proxy/demo.png -r -17208,-9223372036854758600
+$ curl -i http://127.0.0.1:8000/proxy/demo.png -H "Content-Type: image/png; charset=GBK" -r -17208,-9223372036854758600
 ```
 
 看到结果：


### PR DESCRIPTION
<!--
首先非常感谢您能参与到 VulApps 这个开源项目当中来，为你无私奉献的开源精神点赞。

但是在提 PR 之前，我需要你先确认一下下面的基础信息

如果你选中了某一项，可以把该行前面的 `[ ]` 改成 `[x]`。
-->

- [ ] 每个 Commit 都符合 CONTRIBUTING 中提到的规范(https://github.com/Medicean/VulApps/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] PR 中提到的所有环境都在测试构建成功
- [ ] 所涉及到的每个目录中的 README 的索引我也同步更新了

---

**本 PR 都主要是属于哪一类的呢？**

<!--
请删除不符合的选项，并勾选符合的选项
-->

- [ ] 修复已有环境 Bug
- [ ] 新增环境
- [ ] 文档和漏洞描述完善
- [ ] 其它：(请在此描述...)


---

**详细描述**

